### PR TITLE
Add ttnn_<op>_impl.py with ttnn_<op> function to generated kernels

### DIFF
--- a/examples/prompts/combine_op_llk_template.txt
+++ b/examples/prompts/combine_op_llk_template.txt
@@ -40,3 +40,9 @@ Reference the lowering from @code:test_lowered_{{OP_NAME}}.py to see what operat
 @docs:tt-metal-api-reference.xml
 
 /DEBUG_LOOP @command:"timeout 30 python3 test_newop.py"
+
+/PROMPT
+Make the minimal changes to achieve the following:
+Rename @code:ttnn_op_impl.py to `ttnn_{{OP_NAME}}_impl.py`
+Rename the `ttnn_op` function inside @code:ttnn_op_impl.py to `ttnn_{{OP_NAME}}`
+

--- a/examples/prompts/create_cosh_combine_llk_calls.txt
+++ b/examples/prompts/create_cosh_combine_llk_calls.txt
@@ -34,3 +34,9 @@ Reference the lowering from @code:test_lowered_cosh.py to see what operations to
 Make sure to declare any additional CBs you need in @code:test_newop.py prepare_newop_program function - this makes sure you can access them inside kernel @code:tt_eltwise_sfpu2.cpp
 
 /DEBUG_LOOP @command:"python3 test_newop.py"
+
+/PROMPT
+Make the minimal changes to achieve the following:
+Rename @code:ttnn_op_impl.py to `ttnn_cosh_impl.py`
+Rename the `ttnn_op` function inside @code:ttnn_op_impl.py to `ttnn_cosh`
+

--- a/examples/prompts/create_cosh_sfpu.txt
+++ b/examples/prompts/create_cosh_sfpu.txt
@@ -31,3 +31,9 @@ Reference the lowering from @code:test_lowered_cosh.py and implement the operati
 @docs:tt-metal-api-reference.xml
 
 /DEBUG_LOOP @command:"python3 test_newop.py"
+
+/PROMPT
+Make the minimal changes to achieve the following:
+Rename @code:ttnn_op_impl.py to `ttnn_cosh_impl.py`
+Rename the `ttnn_op` function inside @code:ttnn_op_impl.py to `ttnn_cosh`
+

--- a/examples/prompts/create_new_op_from_generic.txt
+++ b/examples/prompts/create_new_op_from_generic.txt
@@ -12,3 +12,9 @@ Other files to reference:
 @docs:tt-metal-api-reference.xml
 
 /DEBUG_LOOP @command:"python3 test_newop.py"
+
+/PROMPT
+Make the minimal changes to achieve the following:
+Rename @code:ttnn_op_impl.py to `ttnn_cosh_impl.py`
+Rename the `ttnn_op` function inside @code:ttnn_op_impl.py to `ttnn_cosh`
+

--- a/examples/templates/ttnn/newop_generic/ttnn_op_impl.py
+++ b/examples/templates/ttnn/newop_generic/ttnn_op_impl.py
@@ -1,0 +1,38 @@
+import math
+import os
+import sys
+import ttnn
+
+# Make sure we can import prepare_newop_program
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from test_newop import prepare_newop_program
+
+def ttnn_op(*args, **kwargs):
+
+    """TTNN implementation matching PyTorch signature"""
+    # assumes one input, no kwargs
+    data = args[0]
+
+    device = ttnn.open_device(device_id=0)
+
+    num_tiles = math.ceil(data.numel() / (32*32))
+    src_bank_id = 0
+    dst_bank_id = 0
+
+    shape = data.shape
+
+    dram_memory_config = ttnn.DRAM_MEMORY_CONFIG
+
+    input_tensor = ttnn.from_torch(data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=dram_memory_config)
+    output_tensor = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device, dram_memory_config)
+    
+    io_tensors = [input_tensor, output_tensor]
+
+    program_descriptor = prepare_newop_program(device, input_tensor, output_tensor, num_tiles, src_bank_id, dst_bank_id)
+
+    output = ttnn.generic_op(io_tensors, program_descriptor)
+    torch_output = ttnn.to_torch(output, dtype=data.dtype)
+
+    ttnn.close_device(device)
+
+    return torch_output


### PR DESCRIPTION
Adds ttnn_op_impl to match expected format for kernel_bench eval
Updates example prompts to request change to template to match actual op name